### PR TITLE
Added Blackman Harris and Rectangular window functions

### DIFF
--- a/interop/src/facade32.rs
+++ b/interop/src/facade32.rs
@@ -906,7 +906,11 @@ pub extern "C" fn ifft_shift32(vector: Box<VecBuf>) -> VectorInteropResult<VecBu
 /// `window` argument is translated to:
 ///
 /// 1. `0` to [`TriangularWindow`](../../window_functions/struct.TriangularWindow.html)
-/// 2. `1` to [`HammingWindow`](../../window_functions/struct.TriangularWindow.html)
+/// 2. `1` to [`HammingWindow`](../../window_functions/struct.HammingWindow.html)
+/// 3. `2` to [`BlackmanHarrisWindow`](../../window_functions/struct.BlackmanHarrisWindow.html)
+/// 4. `3` to [`RectangularWindow`](../../window_functions/struct.RectagnularWindow.html)
+/// 5. Undefined window argument will fall through to
+///    [`RectangularWindow`](../../window_functions/struct.RectagnularWindow.html)
 #[no_mangle]
 pub extern "C" fn apply_window32(vector: Box<VecBuf>, window: i32) -> VectorInteropResult<VecBuf> {
     let window = translate_to_window_function(window);

--- a/interop/src/facade64.rs
+++ b/interop/src/facade64.rs
@@ -907,7 +907,11 @@ pub extern "C" fn ifft_shift64(vector: Box<VecBuf>) -> VectorInteropResult<VecBu
 /// `window` argument is translated to:
 ///
 /// 1. `0` to [`TriangularWindow`](../../window_functions/struct.TriangularWindow.html)
-/// 2. `1` to [`HammingWindow`](../../window_functions/struct.TriangularWindow.html)
+/// 2. `1` to [`HammingWindow`](../../window_functions/struct.HammingWindow.html)
+/// 3. `2` to [`BlackmanHarrisWindow`](../../window_functions/struct.BlackmanHarrisWindow.html)
+/// 4. `3` to [`RectangularWindow`](../../window_functions/struct.RectagnularWindow.html)
+/// 5. Undefined window argument will fall through to
+///    [`RectangularWindow`](../../window_functions/struct.RectagnularWindow.html)
 #[no_mangle]
 pub extern "C" fn apply_window64(vector: Box<VecBuf>, window: i32) -> VectorInteropResult<VecBuf> {
     let window = translate_to_window_function(window);

--- a/interop/src/lib.rs
+++ b/interop/src/lib.rs
@@ -148,10 +148,12 @@ pub fn get_error_marker<T: RealNumber>(vec: &InteropVec<T>) -> i32 {
 pub fn translate_to_window_function<T>(value: i32) -> Box<WindowFunction<T>>
     where T: RealNumber
 {
-    if value == 0 {
-        Box::new(TriangularWindow)
-    } else {
-        Box::new(HammingWindow::default())
+    match value {
+        0 => Box::new(TriangularWindow),
+        1 => Box::new(HammingWindow::default()),
+        2 => Box::new(BlackmanHarrisWindow),
+        3 => Box::new(RectangularWindow),
+        _ => Box::new(RectangularWindow),
     }
 }
 

--- a/vector/src/window_functions.rs
+++ b/vector/src/window_functions.rs
@@ -87,6 +87,48 @@ where
     }
 }
 
+/// A Blackman-Harris Window: `https://en.wikipedia.org/wiki/Window_function#Blackman-Harris_window`
+pub struct BlackmanHarrisWindow;
+impl<T> WindowFunction<T> for BlackmanHarrisWindow
+where
+    T: RealNumber,
+{
+   fn is_symmetric(&self) -> bool {
+       true
+   }
+
+   fn window(&self, n: usize, length: usize) -> T {
+        let one = T::one();
+        let two = T::from(2.0).unwrap();
+        let four = T::from(4.0).unwrap();
+        let six = T::from(6.0).unwrap();
+        let pi = T::PI();
+        let a_naught = T::from(0.35875).unwrap();
+        let a_one = T::from(0.48829).unwrap();
+        let a_two = T::from(0.14128).unwrap();
+        let a_three = T::from(0.01168).unwrap();
+        let n = T::from(n).unwrap();
+        let length = T::from(length).unwrap();
+        a_naught - a_one * (two * pi * n / (length - one)).cos() + a_two * (four * pi * n / (length - one)).cos() - a_three * (six * pi * n / (length - one)).cos()
+   }
+}
+
+/// A rectangular window: `https://en.wikipedia.org/wiki/Window_function#Rectangular_window`
+pub struct RectangularWindow;
+impl<T> WindowFunction<T> for RectangularWindow
+where
+    T: RealNumber,
+{
+    fn is_symmetric(&self) -> bool {
+        true
+    }
+
+    fn window(&self, _n: usize, _length: usize) -> T {
+        let one = T::one();
+        one
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -121,5 +163,19 @@ mod tests {
         let hamming = HammingWindow::<f32>::default();
         let expected = [0.08, 0.54, 1.0, 0.54, 0.08];
         window_test(hamming, &expected);
+    }
+
+    #[test]
+    fn blackmanharris_window32_test() {
+        let blackmanharris = BlackmanHarrisWindow;
+        let expected = [0.0001, 0.2175, 1.0000, 0.2175, 0.0001];
+        window_test(blackmanharris, &expected);
+    }
+
+    #[test]
+    fn rectangular_window32_test() {
+        let rectangular = RectangularWindow;
+        let expected = [1.0, 1.0, 1.0, 1.0, 1.0];
+        window_test(rectangular, &expected);
     }
 }


### PR DESCRIPTION
I added blackman harris and rectangular windows to the window_functions and extended the code in interop to match all of them, and on a failed match, fall through to the RectangularWindow.

I'm happy to add other windows next, but I'd like to send these your way first to get feedback.
Other windows that I think would be good to have next would be a cosine-taper window, Kaiser (-Bessel) window, and maybe a flattop window.  Most of those are fairly straightforward, except the need for a bessel function library or tool for the kaiser window.....